### PR TITLE
virts-306

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -11,4 +11,4 @@ async def initialize(app, services):
     app.router.add_route('*', '/', gui_api.home)
     app.router.add_route('*', '/enter', gui_api.validate_login)
     app.router.add_route('*', '/logout', gui_api.logout)
-    app.router.add_route('*', '/login', gui_api.login)
+    app.router.add_route('GET', '/login', gui_api.login)


### PR DESCRIPTION
Turns out that login was set up to take requests of all types, which is an issue when the exact same landing point is used for Adversary mode's agents, which POST exclusively. There's no reason the login page needs to support POST, so the configuration is modified here.